### PR TITLE
Uncomment line to generate proper semi-colon

### DIFF
--- a/scheme/cyclone/cgen.sld
+++ b/scheme/cyclone/cgen.sld
@@ -355,7 +355,8 @@
     ;(write `(DEBUG ,body))
     (string-append 
      preamble 
-     (c:serialize body "  ") ;" ;\n"
+     (c:serialize body "  ") 
+     " ;\n"
 ;     "int main (int argc, char* argv[]) {\n"
 ;     "  return 0;\n"
 ;     " }\n"


### PR DESCRIPTION
A program as simple as the following:

(import (scheme base)
        (scheme write)
        (srfi 28))

(let ((return-code
       (system "ls")))
  (if (eq? 0 return-code)
      (display 'ok)
      1))

generates a compilation error:

$ cyclone -t test.scm
test.c: In function ‘c_entry_pt_first_lambda’:
test.c:2396:25: error: expected ‘;’ before ‘}’ token
   __halt(obj_int2obj(1))}
                                        ^

Uncommenting on line 358 the "; \n" part makes the code work properly, although it appends semi-colons to code that already have them (without errors).

The fact is that the 'else' clause in the 'if' is converted into (%halt 1), which is itself translated into  __halt(obj_int2obj(1)), which itself does not receives a semi-colon at its end. I couldn't find any other procedure that wouldn't have a semi-colon appended to it, so I suppose this is a corner case (maybe related to  "mclosure0(clos_halt,&Cyc_halt);  // Halt if final closure is reached" on line 94?). 

Justin, if you find where and how %halt is translated to __halt(), could you please point that out to me? I have just spent the last 3 hours searching for it. 

Thanks,
Arthur